### PR TITLE
make entities easier to stack

### DIFF
--- a/src/main/java/net/oldschoolminecraft/pm/PlayerHandler.java
+++ b/src/main/java/net/oldschoolminecraft/pm/PlayerHandler.java
@@ -35,7 +35,11 @@ public class PlayerHandler extends PlayerListener
                 return;
             }
             if (ent.getPassenger() != null) {
-                ent.eject();
+                Entity passent = ent.getPassenger();
+                while (passent != null){
+                    passent = passent.getPassenger();
+                }
+                passent.setPassenger(event.getPlayer());
             }
             else {
                 ent.setPassenger(event.getPlayer());

--- a/src/main/java/net/oldschoolminecraft/pm/PlayerHandler.java
+++ b/src/main/java/net/oldschoolminecraft/pm/PlayerHandler.java
@@ -36,7 +36,7 @@ public class PlayerHandler extends PlayerListener
             }
             if (ent.getPassenger() != null) {
                 Entity passent = ent.getPassenger();
-                while (passent != null){
+                while (passent.getPassenger() != null){
                     passent = passent.getPassenger();
                 }
                 passent.setPassenger(event.getPlayer());


### PR DESCRIPTION
This small pull request makes it easier to stack a lot a of players on top of each other (for example for a fun screenshot)...
Rather than ejecting entity XY when a player clicks the entity it's sitting on, it now checks in a loop for the next entity in the stack that has no passenger, and mounts the player onto that...